### PR TITLE
Remove unnecessary XS-Testsuite field in debian/control.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+apt-clone (0.4.2) UNRELEASED; urgency=medium
+
+  * Remove unnecessary XS-Testsuite field in debian/control.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Tue, 11 Sep 2018 00:01:56 +0100
+
 apt-clone (0.4.1) unstable; urgency=medium
 
   * show friendly error message when restore has no source file

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,6 @@ Build-Depends: debhelper (>= 7.0.50~),
 Standards-Version: 3.9.2
 Vcs-Git: https://github.com/mvo5/apt-clone
 Homepage: https://launchpad.net/apt-clone
-XS-Testsuite: autopkgtest
 
 Package: apt-clone
 Architecture: all


### PR DESCRIPTION
Remove unnecessary XS-Testsuite field in debian/control.

Fixes lintian: xs-testsuite-field-in-debian-control
See https://lintian.debian.org/tags/xs-testsuite-field-in-debian-control.html for more details.
