### PR TITLE
Cache LSB info

### DIFF
--- a/apt_clone.py
+++ b/apt_clone.py
@@ -26,6 +26,7 @@ import fnmatch
 import glob
 import hashlib
 import logging
+import lsb_release
 import os
 import re
 import shutil
@@ -71,7 +72,6 @@ class LowLevelCommands(object):
 
     def debootstrap(self, targetdir, distro=None):
         if distro is None:
-            import lsb_release
             distro = lsb_release.get_distro_information()['CODENAME']
         ret = subprocess.call(["debootstrap", distro, targetdir])
         return (ret == 0)
@@ -187,6 +187,7 @@ class AptClone(object):
         cache = self._cache_cls(rootdir=sourcedir)
         s = ""
         foreign = ""
+        distro_id = lsb_release.get_distro_information()['ID']
         for pkg in cache:
             if pkg.is_installed:
                 # a version identifies the pacakge
@@ -200,8 +201,6 @@ class AptClone(object):
                 for o in pkg.installed.origins:
                     if o.archive == "now" and o.origin == "":
                         continue
-                    import lsb_release
-                    distro_id = lsb_release.get_distro_information()['ID']
                     if o.origin != distro_id:
                         foreign += "%s %s %s\n" % (
                             pkg.name, pkg.installed.version,

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 apt-clone (0.4.2) UNRELEASED; urgency=medium
 
   * Remove unnecessary XS-Testsuite field in debian/control.
+  * Cache distro metadata, speeding up the cloning immensely.
 
  -- Jelmer Vernooĳ <jelmer@debian.org>  Tue, 11 Sep 2018 00:01:56 +0100
 


### PR DESCRIPTION
Currently, dumping the package list takes an incredibly long time.
This commits cuts this time down by a lot (on my system, by two orders of magnitude).

This is because the lsb_release.get_distro_information call
used to create a new process for each package, which is
completely unnecessary.

If the user really insists on changing the OS distribution
*while* running this tool, there is no sane behavior
anyway, so "caching" the release info of the operating system should be fine.