### PR TITLE
d/t/control: depend on ubuntu-keyring instead of ubuntu-archive-keyring

### DIFF
--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,2 +1,2 @@
 Tests: run-tests
-Depends: @, pyflakes3, python3-apt, pycodestyle, python3-mock, python3-distro-info, make, ubuntu-archive-keyring
+Depends: @, pyflakes3, python3-apt, pycodestyle, python3-mock, python3-distro-info, make, ubuntu-keyring


### PR DESCRIPTION
The ubuntu-archive-keyring binary package does not exist in the archive.

autopkgtest is currently failing in Ubuntu Hirsute (development release):

https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac/autopkgtest-hirsute/hirsute/amd64/a/apt-clone/20210127_145044_77992@/log.gz

autopkgtest result with the proposed change:

autopkgtest [15:36:32]: @@@@@@@@@@@@@@@@@@@@ summary
run-tests            PASS
